### PR TITLE
Fix comment typo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ use_html_extension:  false
 open_external_links_in_new_tab: false
 
 # Set to `true` to replace tweet URLs with Twitter embeds.
-# Note that doing so will negatively the reader's privacy
+# Note that doing so will negatively impact the reader's privacy
 # as their browser will communicate with Twitter's servers.
 embed_tweets: true
 


### PR DESCRIPTION
## Summary
- fix a typo in `_config.yml` near `embed_tweets`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841f1eaf160832fba4997182df0266d