### PR TITLE
Fix pagination: process Markdown on generated pages

### DIFF
--- a/_plugins/notes_pagination_generator.rb
+++ b/_plugins/notes_pagination_generator.rb
@@ -4,7 +4,7 @@ module Jekyll
       @site = site
       @base = base
       @dir  = dir
-      @name = 'index.html'
+      @name = index.name
 
       process(@name)
       self.content = index.content


### PR DESCRIPTION
## Summary
- ensure pagination pages inherit index extension so Markdown is processed

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68451b2602ec832fa0cd8e2cf3fac4d7